### PR TITLE
Area under Precision/Recall curve

### DIFF
--- a/R/performance.R
+++ b/R/performance.R
@@ -204,6 +204,7 @@ performance <- function(prediction.obj, measure,
     assign("rpp", "Rate of positive predictions", envir=long.unit.names)
     assign("rnp", "Rate of negative predictions", envir=long.unit.names)
     assign("auc","Area under the ROC curve", envir=long.unit.names)
+    assign("aucpr","Area under the Precision/Recall curve", envir=long.unit.names)
     assign("cal", "Calibration error", envir=long.unit.names)
     assign("mwp", "Median window position", envir=long.unit.names)
     assign("prbe","Precision/recall break-even point", envir=long.unit.names)
@@ -249,6 +250,7 @@ performance <- function(prediction.obj, measure,
     assign("rnp", ".performance.rate.of.negative.predictions",
            envir=function.names)
     assign("auc", ".performance.auc", envir=function.names)
+    assign("aucpr", ".performance.aucpr", envir=function.names)
     assign("cal", ".performance.calibration.error", envir=function.names)
     assign("prbe", ".performance.precision.recall.break.even.point",
            envir=function.names)
@@ -274,6 +276,7 @@ performance <- function(prediction.obj, measure,
     assign("rmse", "none", envir=obligatory.x.axis)
     assign("prbe", "none", envir=obligatory.x.axis)
     assign("auc", "none", envir=obligatory.x.axis)
+    assign("aucpr", "none", envir=obligatory.x.axis)
     assign("rch","none", envir=obligatory.x.axis)
     ## ecost requires probability cost function as x axis, which is handled
     ## implicitly, not as an explicit performance measure.

--- a/R/performance_measures.R
+++ b/R/performance_measures.R
@@ -248,6 +248,53 @@
       return(ans)
   }
 
+
+# written by Thomas Unterthiner (unterthiner@bioinf.jku.at)
+.performance.aucpr <-
+  function(predictions, labels, cutoffs, fp, tp, fn, tn,
+           n.pos, n.neg, n.pos.pred, n.neg.pred) {
+      
+      
+      tmp <- aggregate(list(fp=fp), by=list(tp=tp), min)
+      tp <- tmp$tp
+      fp <- tmp$fp
+      prec <- tp / (fp + tp)
+      rec <- tp / n.pos
+      if (fp[1] == 0 & tp[1] == 0) {
+          prec[1] = 1
+      }
+
+      finite.bool <- is.finite(prec) & is.finite(rec)
+      prec <- prec[ finite.bool ]
+      rec <- rec[ finite.bool ]	
+      if (length(rec) < 2) {
+          stop(paste("Not enough distinct predictions to compute area",
+                     "under the Precision/Recall curve."))
+      }
+            
+      # if two points are too distant from each other, we need to 
+      # correctly interpolate between them. This is done according to
+      # Davis & Goadrich, 
+      #"The Relationship Between Precision-Recall and ROC Curves", ICML'06
+      for (i in seq_along(rec[-length(rec)])) {
+          if (tp[i+1] - tp[i] > 2) {
+              skew = (fp[i+1]-fp[i]) / (tp[i+1]-tp[i])
+              x = seq(1, tp[i+1]-tp[i], by=1)
+              rec <- append(rec, (x+tp[i])/n.pos, after=i)
+              prec <- append(prec, (x+tp[i])/(tp[i]+fp[i]+x+ skew*x), after=i)
+          }
+      }
+
+      auc <- 0
+      for (i in 2:length(rec)) {
+          auc <- auc + 0.5 * (rec[i] - rec[i-1]) * (prec[i] + prec[i-1])
+      }
+    
+      ans <- list( c(), auc)
+      names(ans) <- c("x.values","y.values")
+      return(ans)
+}
+
 .performance.precision.recall.break.even.point <-
   function(predictions, labels, cutoffs, fp, tp, fn, tn,
            n.pos, n.neg, n.pos.pred, n.neg.pred) {

--- a/man/performance.Rd
+++ b/man/performance.Rd
@@ -119,6 +119,9 @@ performance(prediction.obj, measure, x.measure="cutoff", \dots)
       curve. The partial area under the ROC curve up to a given false
       positive rate can be calculated by passing the optional parameter
     \code{fpr.stop=0.5} (or any other value between 0 and 1) to \code{performance}.}
+    \item{\code{aucpr}:}{Area under the Precision/Recall curve. Since the output of
+      \code{aucpr} is cutoff-independent, this measure cannot be combined with 
+      other measures into a parametric curve.}
     \item{\code{prbe}:}{Precision-recall break-even point. The cutoff(s) where
       precision and recall are equal. At this point, positive and negative
       predictions are made at the same rate as their prevalence in the


### PR DESCRIPTION
This commit adds the Area under Precicision/Recall curve measurement as described in Davis & Goadrich, ICML '06
