### PR TITLE
Integer overflow when using "phi" performance

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,0 +1,1 @@
+exportPattern("^[[:alpha:]]+")

--- a/R/performance_measures.R
+++ b/R/performance_measures.R
@@ -110,7 +110,7 @@
            n.pos, n.neg, n.pos.pred, n.neg.pred) {
 
       list(cutoffs,
-           (tn*tp - fn*fp) / sqrt(n.pos * n.neg * n.pos.pred * n.neg.pred) )
+           (tn*tp - fn*fp) / (sqrt(n.pos) * sqrt(n.neg) * sqrt(n.pos.pred) * sqrt(n.neg.pred) ))
   }
 
 .performance.mutual.information <-


### PR DESCRIPTION
+ added NAMESPACE to be able to install from console (why is it missing in the first place?)
+ fixed "mat"/"phi" computation. Now, using larger number of observations will not result in Integer overflow.